### PR TITLE
Read wavefront obj

### DIFF
--- a/tests/test-io-obj.cpp
+++ b/tests/test-io-obj.cpp
@@ -87,6 +87,23 @@ f 4/4/1 3/3/1 1/1/1
 f 5/1/1 6/2/1 7/3/1 8/4/1
 )";
 
+// vt per corner, add some trailing spaces
+static const std::string obj5_str =
+R"(
+v  -1 0 -1
+v  1 0 -1
+v     1 0  1
+v -1 0  1
+
+vt 0 0
+vt 1 0
+vt 1 1
+vt 0 1
+
+f 3/1 2/2 1/3
+f 4/1 3/3 1/4
+)";
+
 
 TEST_CASE("tex_coord per vertex IO test#1", "[OBJ]") {
     static const std::string filename[2] = { "ultimaille-test-tex_coord1-in.obj", "ultimaille-test-tex_coord1-out.obj" };
@@ -191,3 +208,72 @@ TEST_CASE("Polygons IO test", "[OBJ]") {
     }
 }
 
+TEST_CASE("Read/Write/Read Polygons IO test", "[OBJ]") {
+    static const std::string filename[2] = { "ultimaille-test-tex_coord5-in.obj", "ultimaille-test-tex_coord5-out.obj" };
+    std::ofstream ofs(filename[0], std::ofstream::out);
+    ofs << obj5_str;
+    ofs.close();
+
+    {
+        Polygons m;
+        SurfaceAttributes attr = read_by_extension(filename[0], m);
+        REQUIRE( m.nverts()==4 );
+        REQUIRE( m.nfacets()==2 );
+        write_by_extension(filename[1], m, attr);
+    }
+    {
+        Polygons m;
+        SurfaceAttributes attr = read_by_extension(filename[1], m);
+        CHECK( m.nverts()==4 );
+        CHECK( m.nfacets()==2 );
+    }
+}
+
+TEST_CASE("Performance Polygons IO test", "[OBJ]") {
+    static const std::string filename[2] = { "ultimaille-test-tex_coord6-in.obj", "ultimaille-test-tex_coord6-out.obj" };
+
+    for (int z = 3; z < 7; ++z) {
+
+        std::ofstream ofs(filename[0], std::ofstream::out);
+        const int nfacets = 1 * pow(10, z);
+        for (int i = 0; i < nfacets; ++i) {
+            ofs << "v -1 0 -1" << std::endl;
+            ofs << "v 1 0 -1" << std::endl;
+            ofs << "v 1 0  1" << std::endl;
+        }
+        for (int i = 0; i < nfacets; ++i) {
+            ofs << "f " << i * 3 + 1 << " " << i * 3 + 2 << " " << i * 3 + 3 << std::endl;
+        }
+        ofs.close();
+
+        {
+            Polygons m;
+            read_by_extension(filename[0], m);
+            REQUIRE( m.nverts()==nfacets*3);
+            REQUIRE( m.nfacets()==nfacets);
+            write_by_extension(filename[1], m, {});
+        }
+        INFO("ok");
+
+        const int ntry = 10;
+
+        {
+            auto start = std::chrono::system_clock::now();
+            for (int i = 0; i < ntry; ++i) {
+                Polygons m;
+                read_wavefront_obj_old(filename[1], m);
+            }
+            auto end = std::chrono::system_clock::now();
+            std::cout << "duration old: " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start) << std::endl;
+        }
+        {
+            auto start = std::chrono::system_clock::now();
+            for (int i = 0; i < ntry; ++i) {
+                Polygons m;
+                read_wavefront_obj(filename[1], m);
+            }
+            auto end = std::chrono::system_clock::now();
+            std::cout << "duration new: " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start) << std::endl;
+        }
+    }
+}

--- a/ultimaille/io/obj.cpp
+++ b/ultimaille/io/obj.cpp
@@ -43,6 +43,108 @@ namespace UM {
         return {};
     }
 
+    SurfaceAttributes read_wavefront_obj_old(const std::string &filename, Polygons &m) {
+        um_assert(!m.nverts() && !m.nfacets());
+        SurfaceAttributes sa;
+        std::vector<vec3> VN;
+        std::vector<vec2> VT;
+        std::vector<std::vector<int>> VTID;
+        std::vector<std::vector<int>> VNID;
+
+        std::ifstream in;
+        in.open (filename, std::ifstream::in);
+        if (in.fail())
+            throw std::runtime_error("Failed to open " + filename);
+        std::string line;
+        while (!in.eof()) {
+            std::getline(in, line);
+            std::istringstream iss(line.c_str());
+            std::string type_token;
+            iss >> type_token;
+
+            if (type_token=="v") {
+                vec3 v;
+                for (int i=0;i<3;i++) iss >> v[i];
+                m.points.data->push_back(v);
+            } else if (type_token=="vn") {
+                vec3 v;
+                for (int i=0;i<3;i++) iss >> v[i];
+                VN.push_back(v);
+            } else if (type_token=="vt") {
+                vec2 v;
+                for (int i=0;i<2;i++) iss >> v[i];
+                VT.push_back(v);
+            } else if (type_token=="f") {
+                std::vector<int> vid;
+                std::vector<int> vnid;
+                std::vector<int> vtid;
+                int tmp;
+                while (1) { // in wavefront obj all indices start at 1, not zero
+                    while (!iss.eof() && !std::isdigit(iss.peek())) iss.get(); // skip (esp. trailing) white space
+                    if (iss.eof()) break;
+                    iss >> tmp;
+                    vid.push_back(tmp-1);
+                    if (iss.peek() == '/') {
+                        iss.get();
+                        if (iss.peek() == '/') {
+                            iss.get();
+                            iss >> tmp;
+                            vnid.push_back(tmp-1);
+                        } else {
+                            iss >> tmp;
+                            vtid.push_back(tmp-1);
+                            if (iss.peek() == '/') {
+                                iss.get();
+                                iss >> tmp;
+                                vnid.push_back(tmp-1);
+                            }
+                        }
+                    }
+                }
+                VTID.push_back(vtid);
+                VNID.push_back(vnid);
+
+                int off_f = m.create_facets(1, vid.size());
+                for (int i=0; i<static_cast<int>(vid.size()); i++)
+                    m.vert(off_f, i) = vid[i];
+            }
+        }
+
+        bool vt_pt_attr = ((int)VTID.size()==m.nfacets() && (int)VT.size()==m.nverts()); // check whether tex_coord is a PointAttribute
+        if (vt_pt_attr) for (int f=0; f<m.nfacets(); f++) {
+            vt_pt_attr = vt_pt_attr && ((int)VTID[f].size()==m.facet_size(f));
+            if (vt_pt_attr) for (int v=0; v<m.facet_size(f); v++) {
+                vt_pt_attr = vt_pt_attr && (m.vert(f, v)==VTID[f][v]);
+            }
+        }
+
+        if (vt_pt_attr) {
+            PointAttribute<vec2> tex_coord(m.points);
+            for (int v=0; v<m.nverts(); v++)
+                tex_coord[v] = VT[v];
+            sa.points.emplace_back("tex_coord", tex_coord.ptr);
+        } else {
+            bool vt_c_attr = ((int)VTID.size()==m.nfacets() && (int)VT.size()>0); // check whether tex_coord is a CornerAttribute
+            if (vt_c_attr) for (int f=0; f<m.nfacets(); f++) {
+                vt_c_attr = vt_c_attr && ((int)VTID[f].size()==m.facet_size(f));
+            }
+            if (vt_c_attr) {
+                CornerAttribute<vec2> tex_coord(m);
+                for (int f=0; f<m.nfacets(); f++) {
+                    for (int v=0; v<m.facet_size(f); v++) {
+                        um_assert(VTID[f][v]>=0 && VTID[f][v]<(int)VT.size());
+                        tex_coord[m.corner(f, v)] = VT[VTID[f][v]];
+                    }
+                }
+                sa.corners.emplace_back("tex_coord", tex_coord.ptr);
+            }
+        }
+
+        in.close();
+//      std::cerr << "#v: " << m.nverts() << " #f: "  << m.nfacets() << std::endl;
+        return sa;
+    }
+
     // supposes .obj file to have "f " entries without slashes
     // TODO: improve the parser
     // TODO: export vn (corner and point) and vt (corner) attributes

--- a/ultimaille/io/obj.cpp
+++ b/ultimaille/io/obj.cpp
@@ -61,46 +61,61 @@ namespace UM {
         std::string line;
         while (!in.eof()) {
             std::getline(in, line);
-            std::istringstream iss(line.c_str());
-            std::string type_token;
-            iss >> type_token;
+            const char *ptr = line.c_str();
 
-            if (type_token=="v") {
+            if (ptr[0]=='v' && ptr[1] == ' ') {
                 vec3 v;
-                for (int i=0;i<3;i++) iss >> v[i];
+                char* end;
+                v[0] = strtod(ptr + 2, &end);
+                v[1] = strtod(end, &end);
+                v[2] = strtod(end, &end);
                 m.points.data->push_back(v);
-            } else if (type_token=="vn") {
+            } else if (ptr[0]=='v' && ptr[1]=='n' && ptr[2]==' ') {
                 vec3 v;
-                for (int i=0;i<3;i++) iss >> v[i];
+                char* end;
+                v[0] = strtod(ptr + 3, &end);
+                v[1] = strtod(end, &end);
+                v[2] = strtod(end, &end);
                 VN.push_back(v);
-            } else if (type_token=="vt") {
+            } else if (ptr[0]=='v' && ptr[1]=='t' && ptr[2]==' ') {
                 vec2 v;
-                for (int i=0;i<2;i++) iss >> v[i];
+                char* end;
+                v[0] = strtod(ptr + 3, &end);
+                v[1] = strtod(end, &end);
                 VT.push_back(v);
-            } else if (type_token=="f") {
+            } else if (ptr[0]=='f' && ptr[1]==' ') {
                 std::vector<int> vid;
                 std::vector<int> vnid;
                 std::vector<int> vtid;
-                int tmp;
-                while (1) { // in wavefront obj all indices start at 1, not zero
-                    while (!iss.eof() && !std::isdigit(iss.peek())) iss.get(); // skip (esp. trailing) white space
-                    if (iss.eof()) break;
-                    iss >> tmp;
-                    vid.push_back(tmp-1);
-                    if (iss.peek() == '/') {
-                        iss.get();
-                        if (iss.peek() == '/') {
-                            iss.get();
-                            iss >> tmp;
-                            vnid.push_back(tmp-1);
-                        } else {
-                            iss >> tmp;
-                            vtid.push_back(tmp-1);
-                            if (iss.peek() == '/') {
-                                iss.get();
-                                iss >> tmp;
-                                vnid.push_back(tmp-1);
-                            }
+
+                ptr += 2; // Skip "f "
+
+                while (*ptr) {
+                    // Skip whitespace
+                    while (*ptr && std::isspace(*ptr)) ptr++;
+                    if (!*ptr) break;
+
+                    char* end;
+                    int v_idx = strtol(ptr, &end, 10) - 1;
+                    vid.push_back(v_idx);
+                    ptr = end;
+
+                    // Check for texture and normal indices
+                    if (*ptr == '/') {
+                        ptr++; // Skip '/'
+                        
+                        if (*ptr != '/') {
+                            // Has texture index (v/vt or v/vt/vn format)
+                            int vt_idx = strtol(ptr, &end, 10) - 1;
+                            vtid.push_back(vt_idx);
+                            ptr = end;
+                        }
+
+                        if (*ptr == '/') {
+                            ptr++; // Skip '/'
+                            int vn_idx = strtol(ptr, &end, 10) - 1;
+                            vnid.push_back(vn_idx);
+                            ptr = end;
                         }
                     }
                 }

--- a/ultimaille/io/obj.h
+++ b/ultimaille/io/obj.h
@@ -15,6 +15,7 @@ namespace UM {
     SurfaceAttributes read_wavefront_obj(const std::string &filename, Triangles &m);
     SurfaceAttributes read_wavefront_obj(const std::string &filename, Quads  &m);
     SurfaceAttributes read_wavefront_obj(const std::string &filename, Polygons  &m);
+    SurfaceAttributes read_wavefront_obj_old(const std::string &filename, Polygons  &m);
     void write_wavefront_obj(const std::string &filename, const Surface &m, const SurfaceAttributes &attr = {});
     void write_wavefront_obj(const std::string &filename, const PolyLine &m, const PolyLineAttributes &attr = {});
 }


### PR DESCRIPTION
Improve wavefront obj read performances.
<img width="1400" height="500" alt="read-wavefront-obj-polygons" src="https://github.com/user-attachments/assets/7c7e5a1b-d637-49b2-b198-394270c95d50" />

```
Speedup Factor (Old / New):

  1,000 facets: infx faster
  10,000 facets: 4.7x faster
  100,000 facets: 3.8x faster
  1,000,000 facets: 3.6x faster
  10,000,000 facets: 3.5x faster
```

If ok, don't accept, I need to clean up code and do the same thing for `PolyLineAttributes read_wavefront_obj(const std::string &filename, PolyLine &m)`